### PR TITLE
Limit zoom out on ImageViewer

### DIFF
--- a/.changeset/popular-games-sip.md
+++ b/.changeset/popular-games-sip.md
@@ -1,0 +1,5 @@
+---
+"@czb-ui/viz": minor
+---
+
+Add a minimum zoom out

--- a/packages/viz/src/ImageViewer/Image.tsx
+++ b/packages/viz/src/ImageViewer/Image.tsx
@@ -95,6 +95,7 @@ export default function Image({ imageUrl, imageDimensions }: ImageProps) {
         initialViewState={{
           target: [imageDimensions.width / 2, imageDimensions.height / 2, 0], // Start at the center of the image
           zoom: startingZoomLevel,
+          minZoom: startingZoomLevel - 1,
         }}
         layers={[layer]}
       />


### PR DESCRIPTION
Add a minimum zoom based of the starting zoom, instead of being able to zoom out to `-Infinity`