### PR TITLE
Import 400 barlow font and update docs

### DIFF
--- a/.changeset/sour-lizards-buy.md
+++ b/.changeset/sour-lizards-buy.md
@@ -10,4 +10,5 @@ import "@fontsource/hanken-grotesk/700.css";
 import "@fontsource/stix-two-text/600.css";
 import "@fontsource/lato/700.css";
 import "@fontsource/barlow/600.css";
+import "@fontsource/barlow/400.css";
 ```

--- a/apps/czb-ui-storybook/.storybook/preview.tsx
+++ b/apps/czb-ui-storybook/.storybook/preview.tsx
@@ -6,6 +6,7 @@ import "@fontsource/hanken-grotesk/700.css";
 import "@fontsource/stix-two-text/600.css";
 import "@fontsource/lato/700.css";
 import "@fontsource/barlow/600.css";
+import "@fontsource/barlow/400.css";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/apps/docs/content/docs/installation.md
+++ b/apps/docs/content/docs/installation.md
@@ -28,10 +28,12 @@ Additionally import the fonts installed.
 ```javascript
 import { ThemeProvider } from "@czb-ui/core";
 
-import "@fontsource/barlow/700.css"; // We only need bold weight
-import "@fontsource/lato/700.css"; // We only need bold weight
-import "@fontsource/hanken-grotesk";
-import "@fontsource/stix-two-text";
+import "@fontsource/hanken-grotesk/400.css";
+import "@fontsource/hanken-grotesk/700.css";
+import "@fontsource/stix-two-text/600.css";
+import "@fontsource/lato/700.css";
+import "@fontsource/barlow/600.css";
+import "@fontsource/barlow/400.css";
 
 function MyApp({ Component, pageProps }) {
   return (

--- a/apps/docs/pages/_app.js
+++ b/apps/docs/pages/_app.js
@@ -13,6 +13,7 @@ import "@fontsource/hanken-grotesk/700.css";
 import "@fontsource/stix-two-text/600.css";
 import "@fontsource/lato/700.css";
 import "@fontsource/barlow/600.css";
+import "@fontsource/barlow/400.css";
 
 // Import Butler font
 import "../public/fonts/Butler.css";

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,10 +21,12 @@ Wrap the `ThemeProvider` in your main `app.js` file and import the fonts at thei
 ```jsx
 import { ThemeProvider } from "@czb-ui/core";
 
-import "@fontsource/barlow/700.css"; // We only need bold weight
-import "@fontsource/lato/700.css"; // We only need bold weight
-import "@fontsource/hanken-grotesk";
-import "@fontsource/stix-two-text";
+import "@fontsource/hanken-grotesk/400.css";
+import "@fontsource/hanken-grotesk/700.css";
+import "@fontsource/stix-two-text/600.css";
+import "@fontsource/lato/700.css";
+import "@fontsource/barlow/600.css";
+import "@fontsource/barlow/400.css";
 
 function MyApp({ Component, pageProps }) {
   return (


### PR DESCRIPTION
Import the 400 weight of Barlow since some `czifui` components used it.

Also update docs on importing all the fonts.