### PR TITLE
Fix crash in BlockSwitcher when passing in a custom template for additionalBlocks

### DIFF
--- a/.changeset/two-turkeys-smile.md
+++ b/.changeset/two-turkeys-smile.md
@@ -1,0 +1,5 @@
+---
+"@czb-ui/tinacms": patch
+---
+
+Fix crash in BlockSwitcher when passing in a custom template for additionalBlocks

--- a/packages/tinacms/src/utils/BlockSwitcher.tsx
+++ b/packages/tinacms/src/utils/BlockSwitcher.tsx
@@ -50,13 +50,24 @@ export const BlockSwitcher = (props: BlockSwitcher) => {
               .replace(/Blocks/g, "");
 
             try {
+              if (usableBlocks[blockToLookFor] === undefined) {
+                throw new Error(
+                  "Block not found. Is it supplied in the additionalBlocks prop?"
+                );
+              }
               return React.createElement(usableBlocks[blockToLookFor], {
                 block,
                 key: i,
                 ...props,
               });
-            } catch (e) {
+            } catch (e: any) {
               console.error(e);
+              return (
+                <div>
+                  Something went wrong rendering the {blockToLookFor} block:{" "}
+                  {e.message}
+                </div>
+              );
             }
           })
         : null}


### PR DESCRIPTION
- Fix crash in BlockSwitcher when passing in a custom template for additionalBlocks
