### PR TITLE
Fix hydration error caused by rich-text images

### DIFF
--- a/.changeset/moody-pandas-grab.md
+++ b/.changeset/moody-pandas-grab.md
@@ -1,0 +1,5 @@
+---
+"@czb-ui/tinacms": patch
+---
+
+Fix hydration error with rich-text images

--- a/packages/tinacms/src/components/Text/TextBlock.tsx
+++ b/packages/tinacms/src/components/Text/TextBlock.tsx
@@ -103,7 +103,15 @@ const imgComponent = (props: ImageProps) => {
   // TODO: Get palette grey for background
   // that shows when there is no image
   return (
-    <Box sx={{ position: "relative", height: "300px", my: "20px" }}>
+    <Box
+      sx={{
+        position: "relative",
+        height: "300px",
+        my: "20px",
+        display: "block",
+      }}
+      component="span"
+    >
       {props.url && (
         <Image
           src={props.url}
@@ -123,6 +131,7 @@ const imgComponent = (props: ImageProps) => {
             justifyContent: "center",
             alignItems: "center",
           }}
+          component="span"
         >
           <Typography variant="h1" component="div">
             Please put an image


### PR DESCRIPTION
Use span instead of div for a container, as [nesting `div` in `p` isn't correct](https://nextjs.org/docs/messages/react-hydration-error), and `TinaMarkdown` always wraps images in `p`.