### PR TITLE
Improve mobile nav bar list

### DIFF
--- a/.changeset/selfish-guests-switch.md
+++ b/.changeset/selfish-guests-switch.md
@@ -1,0 +1,5 @@
+---
+"@czb-ui/core": minor
+---
+
+Improve mobile nav bar list

--- a/packages/core/src/AppBar/AppBar.tsx
+++ b/packages/core/src/AppBar/AppBar.tsx
@@ -3,11 +3,12 @@ import Toolbar, { ToolbarProps } from "@mui/material/Toolbar";
 import { styled } from "@mui/material/styles";
 
 const AppBarComponent = styled(MaterialAppBar)<AppBarProps>(({ theme }) => ({
-  backgroundColor: "inherit",
+  backgroundColor: theme.palette.background.default,
   color: theme.palette.text.primary,
   boxShadow: "none",
   borderBottom: "1px solid",
   borderColor: theme.palette.divider,
+  zIndex: 9999,
 })) as typeof MaterialAppBar;
 
 interface ToolbarComponentProps extends ToolbarProps {

--- a/packages/core/src/NavBar/MobilePagesMenu.tsx
+++ b/packages/core/src/NavBar/MobilePagesMenu.tsx
@@ -6,6 +6,7 @@ import {
   ClickAwayListener,
   ListItem,
   List,
+  Divider,
 } from "@mui/material";
 import Hamburger from "hamburger-react";
 import { useState } from "react";
@@ -39,32 +40,39 @@ export const MobilePagesMenu = ({
             },
           }}
         >
-          <List>
+          <List disablePadding>
             {pages.map((page, i) => (
-              <ListItem disableGutters key={i}>
-                {!page.externalLink && (
-                  <Link
-                    color="inherit"
-                    component={page?.to ? pagesComponent : undefined}
-                    to={page?.to}
-                    sx={{ mx: 5 }}
-                    onClick={() => setOpen(false)}
-                  >
-                    <ListItemButton>{page.title}</ListItemButton>
-                  </Link>
-                )}
-                {/* If target="_blank" needs to be added also add rel="noopener" */}
-                {page.externalLink && (
-                  <Link
-                    color="inherit"
-                    sx={{ mx: 5 }}
-                    onClick={() => setOpen(false)}
-                    href={page?.to}
-                  >
-                    <ListItemButton>{page.title}</ListItemButton>
-                  </Link>
-                )}
-              </ListItem>
+              <>
+                <Divider component="li" />
+                <ListItem disableGutters disablePadding key={i}>
+                  {!page.externalLink && (
+                    <Link
+                      color="inherit"
+                      component={page?.to ? pagesComponent : undefined}
+                      to={page?.to}
+                      sx={{ mx: 5, width: "100%" }}
+                      onClick={() => setOpen(false)}
+                    >
+                      <ListItemButton sx={{ p: 6 }}>
+                        {page.title}
+                      </ListItemButton>
+                    </Link>
+                  )}
+                  {/* If target="_blank" needs to be added also add rel="noopener" */}
+                  {page.externalLink && (
+                    <Link
+                      color="inherit"
+                      sx={{ mx: 5, width: "100%" }}
+                      onClick={() => setOpen(false)}
+                      href={page?.to}
+                    >
+                      <ListItemButton sx={{ p: 6 }}>
+                        {page.title}
+                      </ListItemButton>
+                    </Link>
+                  )}
+                </ListItem>
+              </>
             ))}
           </List>
         </Drawer>

--- a/packages/core/src/NavBar/MobilePagesMenu.tsx
+++ b/packages/core/src/NavBar/MobilePagesMenu.tsx
@@ -30,7 +30,6 @@ export const MobilePagesMenu = ({
       <Box>
         <Hamburger toggled={open} toggle={setOpen} />
         <Drawer
-          variant="persistent"
           anchor="top"
           open={open}
           onClose={() => setOpen(false)}


### PR DESCRIPTION
Allow button to be clickable in the full width. Also add separators between each button. The rest of the page also darkens when the menu is open.